### PR TITLE
Avoid calling the maven-dependency-plugin for all builds

### DIFF
--- a/core/META-INF/MANIFEST.MF
+++ b/core/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: m2e connector for Maven Dependency Plugin
 Bundle-SymbolicName: com.ianbrandt.tools.m2e.mdp.core;singleton:=true
-Bundle-Version: 0.0.2.qualifier
+Bundle-Version: 0.0.3.qualifier
 Bundle-Vendor: Ian Brandt
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.4.0",
  org.eclipse.core.runtime;bundle-version="3.4.0",
- org.eclipse.m2e.jdt;bundle-version="1.0.0",
- org.eclipse.m2e.core;bundle-version="1.0.0",
- org.eclipse.m2e.maven.runtime;bundle-version="1.0.0"
+ org.eclipse.m2e.jdt;bundle-version="1.4.0",
+ org.eclipse.m2e.core;bundle-version="1.4.0",
+ org.eclipse.m2e.maven.runtime;bundle-version="1.4.0"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.ianbrandt</groupId>
 		<artifactId>m2e-maven-dependency-plugin-parent</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>com.ianbrandt.tools.m2e.mdp.core</artifactId>

--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="com.ianbrandt.tools.m2e.mdp.feature"
-		label="%featureName"
-		version="0.0.2.qualifier"
-		plugin="com.ianbrandt.tools.m2e.mdp.core">
+<feature
+      id="com.ianbrandt.tools.m2e.mdp.feature"
+      label="%featureName"
+      version="0.0.3.qualifier"
+      plugin="com.ianbrandt.tools.m2e.mdp.core">
 
-	<description>
-		%description
-	</description>
+   <description>
+      %description
+   </description>
 
-	<copyright>
-		%copyright
-	</copyright>
+   <copyright>
+      %copyright
+   </copyright>
 
-	<license url="%licenseURL">
-		%license
-	</license>
+   <license url="%licenseURL">
+      %license
+   </license>
 
-	<plugin id="com.ianbrandt.tools.m2e.mdp.core"
-			download-size="0"
-			install-size="0"
-			version="0.0.0"
-			unpack="false"/>
+   <plugin
+         id="com.ianbrandt.tools.m2e.mdp.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.ianbrandt</groupId>
 		<artifactId>m2e-maven-dependency-plugin-parent</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>com.ianbrandt.tools.m2e.mdp.feature</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>com.ianbrandt</groupId>
 	<artifactId>m2e-maven-dependency-plugin-parent</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>M2E Connector for Maven Dependency Plugin Parent</name>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.ianbrandt</groupId>
 		<artifactId>m2e-maven-dependency-plugin-parent</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>com.ianbrandt.tools.m2e.mdp.site</artifactId>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: m2e connector for Maven Dependency Plugin Tests
 Bundle-SymbolicName: com.ianbrandt.tools.m2e.mdp.tests
-Bundle-Version: 0.0.2.qualifier
+Bundle-Version: 0.0.3.qualifier
 Bundle-Vendor: Ian Brandt
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="1.0.0",

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.ianbrandt</groupId>
 		<artifactId>m2e-maven-dependency-plugin-parent</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>com.ianbrandt.tools.m2e.mdp.tests</artifactId>

--- a/tests/projects/smoketest/pom.xml
+++ b/tests/projects/smoketest/pom.xml
@@ -6,6 +6,13 @@
 	<artifactId>smoketest</artifactId>
 	<version>0.0.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+		</dependency>
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
@@ -21,9 +28,9 @@
 						<configuration>
 							<artifactItems>
 								<artifactItem>
-									<groupId>com.ianbrandt</groupId>
-									<artifactId>com.ianbrandt.tools.m2e.mdp.core</artifactId>
-									<version>0.0.2-SNAPSHOT</version>
+									<groupId>junit</groupId>
+									<artifactId>junit</artifactId>
+									<version>4.10</version>
 									<outputDirectory>${project.build.directory}/generated-resources/</outputDirectory>
 								</artifactItem>
 							</artifactItems>

--- a/tests/src/com/ianbrandt/tools/m2e/mdp/tests/M2eMdpConnectorTest.java
+++ b/tests/src/com/ianbrandt/tools/m2e/mdp/tests/M2eMdpConnectorTest.java
@@ -2,25 +2,45 @@ package com.ianbrandt.tools.m2e.mdp.tests;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 
 @SuppressWarnings("restriction")
 public class M2eMdpConnectorTest extends AbstractMavenProjectTestCase {
 
-	public void testM2eMdpForSmoke() throws Exception {
-
-		IProject project = importProject("projects/smoketest/pom.xml");
-
+	public void testShouldNotUnpackDependency() throws Exception {
+		// given
+		final IProject project = importProject("projects/smoketest/pom.xml");
 		waitForJobsToComplete();
-
+		project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+		waitForJobsToComplete();
+		// make sure target/generated-resources is empty
+		final IResource targetResourcesFolder = project.findMember(new Path("target").append("generated-resources"));
+		if(targetResourcesFolder != null) {
+			targetResourcesFolder.delete(true, new NullProgressMonitor());
+		}
+		// when further auto build is performed
 		project.build(IncrementalProjectBuilder.AUTO_BUILD, monitor);
-
 		waitForJobsToComplete();
+		// then
+		final IFile testResource = project
+				.getFile("target/generated-resources/LICENSE.txt");
+		assertFalse(testResource.getName() + " is missing", testResource.exists());
+	}
 
-		IFile testResource = project
-				.getFile("target/generated-resources/plugin.xml");
-
+	public void testShouldUnpackDependency() throws Exception {
+		// given
+		final IProject project = importProject("projects/smoketest/pom.xml");
+		waitForJobsToComplete();
+		// when
+		project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+		waitForJobsToComplete();
+		// then
+		final IFile testResource = project
+				.getFile("target/generated-resources/LICENSE.txt");
 		assertTrue(testResource.getName() + " is missing", testResource.exists());
 	}
 }


### PR DESCRIPTION
Only trigger the maven-dependency-plugin when the there's a full build or when the pom.xml is part of the incremental changes
Also, replace calls to deprecated methods and added tests to check that the maven-dependency-plugin is called or not (using the junit:junit:4.10
artifact instead of the plugin itself, which doesn't work unless it has been installed in the local repo at least once before)
